### PR TITLE
Fix loading orkl sites on HTTPs domains.

### DIFF
--- a/src/orkl.js
+++ b/src/orkl.js
@@ -14,7 +14,7 @@ module.exports = orkl
 function orkl () {
 	return function plugin(state, emitter) {
 		try {
-			var archive = new DatArchive(window.location.origin + '/')
+			var archive = new DatArchive(window.location.origin.replace(/^https?/, 'dat') + '/')
 			var fs = makeDatFs(archive)
 			state.p2p = true
 		} catch (err) {


### PR DESCRIPTION
I was unable to load the site I made, https://rangermauve.hashbase.io/ , wasn't loading posts when it wasn't served from `dat://`. I think I tracked the problem down to this line and it seems to have fixed the problem.